### PR TITLE
allow DELETE method for forms

### DIFF
--- a/course_api/typeform/api_views.py
+++ b/course_api/typeform/api_views.py
@@ -38,12 +38,12 @@ class TestView(GenericViewSet):
         ])
 
 
-class FormViewSet(RetrieveModelMixin, ListModelMixin, UpdateModelMixin, GenericViewSet, CreateModelMixin):
+class FormViewSet(ModelViewSet):
     serializer_class = FormSerializer
     queryset = Form.objects.all()
 
     def get_queryset(self, *args, **kwargs):
-        updateMethods = ['patch', 'update', 'partial_update']
+        updateMethods = ['patch', 'update', 'partial_update', 'delete']
         if(self.request.user.is_anonymous and self.action not in updateMethods):
             return self.queryset.filter(is_public=True)
         if(self.request.user.is_anonymous):


### PR DESCRIPTION
the `Form` model inherits `course_api.utils.models.base.BaseModel` which already has soft delete implementation, so we just had to allow that on the view level.