### PR TITLE
Allow CORS for all origins

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -333,6 +333,5 @@ SPECTACULAR_SETTINGS = {
 }
 # Your stuff...
 # ------------------------------------------------------------------------------
-CORS_ALLOWED_ORIGINS = [
-    "http://localhost:3000",
-]
+CORS_ALLOW_ALL_ORIGINS = True
+


### PR DESCRIPTION
Seems like the `django-cors-headers` is enabled but not configured properly. 

This change sets the CORS to work for all domains and not just `localhost:3000` . In this way, the user can access the api from a site deployed on any domain. 